### PR TITLE
Patched Biomes'o'plenty crash

### DIFF
--- a/src/main/java/net/smart/moving/SMOrientation.java
+++ b/src/main/java/net/smart/moving/SMOrientation.java
@@ -2361,7 +2361,11 @@ public class SMOrientation {
 	}
 
 	private static EnumFacing getValue(IBlockState state, PropertyDirection property) {
-		return state.getValue(property);
+		try {
+			return state.getValue(property);
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
 	}
 
 	private static Enum getValue(IBlockState state, PropertyEnum property) {


### PR DESCRIPTION
Only slight patch, Biomes'o'Plenty uses a different system for orientation (has a collection of booleans, one for each direction), this fix simply catches the illegal argument exception and returns null